### PR TITLE
hide left drawer and left drawer toggle when in fullscreen mode.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -27,3 +27,13 @@
     display: none;
     visibility: hidden;
 }
+
+.atto-fullscreen .drawer.drawer-left {
+    display: none;
+    visibility: hidden;
+}
+
+.atto-fullscreen .drawer-left-toggle {
+    display: none;
+    visibility: hidden;
+}


### PR DESCRIPTION
refs #20 

![image](https://github.com/dthies/moodle-atto_fullscreen/assets/1410427/b91c9084-8858-4e89-955c-134026367b69)


click tested with latest Firefox and Chromium on Moodle 4.3 and 4.4.

regression click-tested on Moodle 4.1 and 4.2.